### PR TITLE
Melhoria na navegação entre os slides

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -294,6 +294,17 @@ div.jequiti-background {
 .nickname .message {
   font-size: 30px;
 }
+.goto {
+    position: fixed;
+    height: 2em;
+    bottom: 4.6em;
+    right: 4.5em;
+    width:2em;
+    z-index: 9999999;
+    background: #59AFB6;
+    border: none;
+    border-radius: 10em;
+}
 
 /******************** Ids ********************/
 /******************** Media Queries ********************/

--- a/public/js/code.min.js
+++ b/public/js/code.min.js
@@ -129,7 +129,7 @@ Modules.counter = {
 Modules.goto = {
     targets : {},
     start: function () {
-        $('.goto').on('click', function (event) {
+        $('.goto').on('click', function () {
             target = prompt('Para onde vamos maninho?');
 
             try {
@@ -329,6 +329,7 @@ Modules.sound = {
 		 createjs.Sound.registerSound('sounds/qualresposta.ogg', 'qualresposta');
 		 createjs.Sound.registerSound('sounds/suspense02.ogg', 'suspense02');
 		 createjs.Sound.registerSound('sounds/tchau.ogg', 'tchau');
+		 createjs.Sound.registerSound('sounds/mgsalert.ogg', 'mgsalert');
 
 		 Reveal.addEventListener('slidechanged', function( event ) {
 			Modules.sound.checkCurrentSlide(event.currentSlide);
@@ -360,6 +361,9 @@ Modules.sound = {
 	    	instance.volume = 0.5;
 		}  else if ($(currentSlide).hasClass('sound-tchau')) {
 			instance = createjs.Sound.play('tchau');
+	    	instance.volume = 0.5;
+		}  else if ($(currentSlide).hasClass('sound-mgsalert')) {
+			instance = createjs.Sound.play('mgsalert');
 	    	instance.volume = 0.5;
 		}
 	}

--- a/public/js/code.min.js
+++ b/public/js/code.min.js
@@ -135,7 +135,6 @@ Modules.goto = {
             try {
                 slideNumber = Modules.goto.findSlideNumber(target);
                 Reveal.slide(slideNumber);
-                ratchet.emit('slide', slideNumber);
             } catch (e) {
                 alert('Não encontramos o slide especificado.');
             }

--- a/public/js/code.min.js
+++ b/public/js/code.min.js
@@ -122,9 +122,62 @@ Modules.counter = {
 
 	callback: function(data) {
 		if (data.type == 'counter') {
-			$('.users-counter').html(parseInt(data.number/2));
+			$('.users-counter').html(parseInt(data.number));
 		}
 	},
+}
+Modules.goto = {
+    targets : {},
+    start: function () {
+        $('.goto').on('click', function (event) {
+            target = prompt('Para onde vamos maninho?');
+
+            try {
+                Reveal.slide(Modules.goto.findSlideNumber(target));
+            } catch (e) {
+                alert('Não encontramos o slide especificado.');
+            }
+        });
+    },
+
+    findSlideNumber: function (target) {
+        if (!Modules.goto.validateTarget(target)) {
+            throw {
+                name: 'InvalidTarget',
+                message: 'Target not found'
+            }
+        }
+
+        if (isNaN(target)) {
+            return Modules.goto.targets[target];
+        }
+
+        return target;
+    },
+
+    register: function (keys, slide) {
+        if (!Array.isArray(keys)) {
+            keys = [keys];
+        }
+
+        keys.forEach(function (key) {
+            Modules.goto.targets[key] = slide;
+        });
+    },
+
+    validateTarget: function (target) {
+        if (undefined != Modules.goto.targets[target]) {
+            return true;
+        }
+
+        if (isNaN(target)) {
+            return false;
+        }
+
+        slideNumber = target;
+
+        return slideNumber > -1 && slideNumber <= Reveal.getTotalSlides();
+    },
 }
 Modules.horn = {
 	start: function() {

--- a/public/js/code.min.js
+++ b/public/js/code.min.js
@@ -133,7 +133,9 @@ Modules.goto = {
             target = prompt('Para onde vamos maninho?');
 
             try {
-                Reveal.slide(Modules.goto.findSlideNumber(target));
+                slideNumber = Modules.goto.findSlideNumber(target);
+                Reveal.slide(slideNumber);
+                ratchet.emit('slide', slideNumber);
             } catch (e) {
                 alert('Não encontramos o slide especificado.');
             }

--- a/public/js/code.min.js
+++ b/public/js/code.min.js
@@ -122,12 +122,13 @@ Modules.counter = {
 
 	callback: function(data) {
 		if (data.type == 'counter') {
-			$('.users-counter').html(parseInt(data.number));
+			$('.users-counter').html(parseInt(data.number/2));
 		}
 	},
 }
 Modules.goto = {
     targets : {},
+
     start: function () {
         $('.goto').on('click', function () {
             target = prompt('Para onde vamos maninho?');
@@ -178,8 +179,8 @@ Modules.goto = {
         slideNumber = target;
 
         return slideNumber > -1 && slideNumber <= Reveal.getTotalSlides();
-    },
-}
+    }
+};
 Modules.horn = {
 	start: function() {
 		//Listener do botão
@@ -325,11 +326,11 @@ Modules.sound = {
 	start: function() {
 		 createjs.Sound.alternateExtensions = ['mp3'];
 		 createjs.Sound.registerSound('sounds/horn.ogg', 'horn');
-		 createjs.Sound.registerSound('sounds/comecar.ogg', 'comecar');
-		 createjs.Sound.registerSound('sounds/qualresposta.ogg', 'qualresposta');
-		 createjs.Sound.registerSound('sounds/suspense02.ogg', 'suspense02');
-		 createjs.Sound.registerSound('sounds/tchau.ogg', 'tchau');
-		 createjs.Sound.registerSound('sounds/mgsalert.ogg', 'mgsalert');
+        createjs.Sound.registerSound('sounds/comecar.ogg', 'comecar');
+        createjs.Sound.registerSound('sounds/qualresposta.ogg', 'qualresposta');
+        createjs.Sound.registerSound('sounds/suspense02.ogg', 'suspense02');
+        createjs.Sound.registerSound('sounds/tchau.ogg', 'tchau');
+        createjs.Sound.registerSound('sounds/mgsalert.ogg', 'mgsalert');
 
 		 Reveal.addEventListener('slidechanged', function( event ) {
 			Modules.sound.checkCurrentSlide(event.currentSlide);
@@ -360,12 +361,12 @@ Modules.sound = {
 			instance = createjs.Sound.play('suspense02');
 	    	instance.volume = 0.5;
 		}  else if ($(currentSlide).hasClass('sound-tchau')) {
-			instance = createjs.Sound.play('tchau');
-	    	instance.volume = 0.5;
-		}  else if ($(currentSlide).hasClass('sound-mgsalert')) {
-			instance = createjs.Sound.play('mgsalert');
-	    	instance.volume = 0.5;
-		}
+            instance = createjs.Sound.play('tchau');
+            instance.volume = 0.5;
+        }  else if ($(currentSlide).hasClass('sound-mgsalert')) {
+            instance = createjs.Sound.play('mgsalert');
+            instance.volume = 0.5;
+        }
 	}
 };
 //$(document).ready(function() {

--- a/public/js/modules/goto.js
+++ b/public/js/modules/goto.js
@@ -1,5 +1,6 @@
 Modules.goto = {
     targets : {},
+
     start: function () {
         $('.goto').on('click', function () {
             target = prompt('Para onde vamos maninho?');

--- a/public/js/modules/goto.js
+++ b/public/js/modules/goto.js
@@ -1,0 +1,54 @@
+Modules.goto = {
+    targets : {},
+    start: function () {
+        $('.goto').on('click', function () {
+            target = prompt('Para onde vamos maninho?');
+
+            try {
+                slideNumber = Modules.goto.findSlideNumber(target);
+                Reveal.slide(slideNumber);
+            } catch (e) {
+                alert('Não encontramos o slide especificado.');
+            }
+        });
+    },
+
+    findSlideNumber: function (target) {
+        if (!Modules.goto.validateTarget(target)) {
+            throw {
+                name: 'InvalidTarget',
+                message: 'Target not found'
+            }
+        }
+
+        if (isNaN(target)) {
+            return Modules.goto.targets[target];
+        }
+
+        return target;
+    },
+
+    register: function (keys, slide) {
+        if (!Array.isArray(keys)) {
+            keys = [keys];
+        }
+
+        keys.forEach(function (key) {
+            Modules.goto.targets[key] = slide;
+        });
+    },
+
+    validateTarget: function (target) {
+        if (undefined != Modules.goto.targets[target]) {
+            return true;
+        }
+
+        if (isNaN(target)) {
+            return false;
+        }
+
+        slideNumber = target;
+
+        return slideNumber > -1 && slideNumber <= Reveal.getTotalSlides();
+    }
+};

--- a/public/js/modules/sound.js
+++ b/public/js/modules/sound.js
@@ -2,10 +2,11 @@ Modules.sound = {
 	start: function() {
 		 createjs.Sound.alternateExtensions = ['mp3'];
 		 createjs.Sound.registerSound('sounds/horn.ogg', 'horn');
-		 createjs.Sound.registerSound('sounds/comecar.ogg', 'comecar');
-		 createjs.Sound.registerSound('sounds/qualresposta.ogg', 'qualresposta');
-		 createjs.Sound.registerSound('sounds/suspense02.ogg', 'suspense02');
-		 createjs.Sound.registerSound('sounds/tchau.ogg', 'tchau');
+        createjs.Sound.registerSound('sounds/comecar.ogg', 'comecar');
+        createjs.Sound.registerSound('sounds/qualresposta.ogg', 'qualresposta');
+        createjs.Sound.registerSound('sounds/suspense02.ogg', 'suspense02');
+        createjs.Sound.registerSound('sounds/tchau.ogg', 'tchau');
+        createjs.Sound.registerSound('sounds/mgsalert.ogg', 'mgsalert');
 
 		 Reveal.addEventListener('slidechanged', function( event ) {
 			Modules.sound.checkCurrentSlide(event.currentSlide);
@@ -36,8 +37,11 @@ Modules.sound = {
 			instance = createjs.Sound.play('suspense02');
 	    	instance.volume = 0.5;
 		}  else if ($(currentSlide).hasClass('sound-tchau')) {
-			instance = createjs.Sound.play('tchau');
-	    	instance.volume = 0.5;
-		}
+            instance = createjs.Sound.play('tchau');
+            instance.volume = 0.5;
+        }  else if ($(currentSlide).hasClass('sound-mgsalert')) {
+            instance = createjs.Sound.play('mgsalert');
+            instance.volume = 0.5;
+        }
 	}
 };

--- a/resources/views/talks.blade.php
+++ b/resources/views/talks.blade.php
@@ -82,7 +82,11 @@
 			</div>
 		</div>
 
-        <img class="fullscreenimg" onclick="toggleFullScreen();" src="images/fullscreen.png" style="position: fixed; bottom: 1em; right: 1em; width:2 em; z-index: 9999999;">
+        <?php if ($mode == 'presenter') : ?>
+            <input type="button" class="goto" />
+        <?php endif; ?>
+
+        <img class="fullscreenimg" onclick="toggleFullScreen();" src="images/fullscreen.png" style="position: fixed; bottom: 1em; right: 1em; width:2em; z-index: 9999999;">
 
 		<script src="js/plugins/jquery.min.js"></script>
 		<script src="lib/js/head.min.js"></script>
@@ -96,5 +100,20 @@
 
         <!-- Other -->
         @include('partials.other')
+
+        <script>
+            // Gambiarra marota que espera o carregamento dos módulos
+            setTimeout(function () {
+                Modules.goto.register('sorteio', 335);
+                Modules.goto.register('painel', 226);
+
+                Modules.goto.register(['funcional', '@marcelgsantos'], 1);
+                Modules.goto.register(['eda', '@edsonlimadev'], 86);
+                Modules.goto.register(['react', '@nawarian'], 118);
+                Modules.goto.register(['jwt', '@ivanrosolen'], 134);
+                Modules.goto.register(['psr7', '@danizord'], 176);
+                Modules.goto.register(['automação', '@diegopires'], 228);
+            }, 300);
+        </script>
 	</body>
 </html>


### PR DESCRIPTION
Adicionei um botão entre as setas de navegação que serve para fazer o salto entre os slides.
Através dele podemos acessar um slide pelo seu indice ou podemos registrá-lo no módulo para que seja possível acessá-lo através de alguma palavra chave.

![goto-button](https://cloud.githubusercontent.com/assets/6683189/12704968/f2879e3a-c84d-11e5-9900-cfc8a78809ca.png)
![prompt-goto](https://cloud.githubusercontent.com/assets/6683189/12704970/faec0d04-c84d-11e5-8ea5-69d2176ed0dc.png)

As seguintes keywords foram registradas:

``` js
Modules.goto.register('sorteio', 335);
Modules.goto.register('painel', 226);
Modules.goto.register(['funcional', '@marcelgsantos'], 1);
Modules.goto.register(['eda', '@edsonlimadev'], 86);
Modules.goto.register(['react', '@nawarian'], 118);
Modules.goto.register(['jwt', '@ivanrosolen'], 134);
Modules.goto.register(['psr7', '@danizord'], 176);
Modules.goto.register(['automação', '@diegopires'], 228);
```

Fora isso também foi registrado o áudio que eu havia esquecido de adicionar na minha palestra :p
